### PR TITLE
Add table stats for cells scanned / speculative retries / space used

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Seastat is different to other exporters for Cassandra such as the [JMX Exporter]
 
 Seastat is used for scraping metrics for more than 1,000 tables across hundreds of keyspaces every minute without sweat 😅. It is built for performance by batching queries when it makes sense and limiting the amount of data it exposes to be scalable. More metrics may be added in the future but with careful consideration to not negatively impact performance.
 
-A very (non-scientific) test with 4000 tables across 200 keyspaces took between 7-10 seconds to scrape all stats exposed. Both the standalone Cassandra Exporter and the Prometheus JMX Exporter took over 10 minutes because they query for each MBean for each table individually which is very expensive. This test was done using Cassandra running in the Docker harness (with 4 cores and 8GB of RAM on  a completely idle cluster of 1). Your mileage may vary and you should do your own tests!
+A very (non-scientific) test with 4000 tables across 200 keyspaces took between 10-15 seconds to scrape all stats exposed. Both the standalone Cassandra Exporter and the Prometheus JMX Exporter took over 10 minutes because they query for each MBean for each table individually which is very expensive. This test was done using Cassandra running in the Docker harness (with 4 cores and 8GB of RAM on  a completely idle cluster of 1). Your mileage may vary and you should do your own tests!
 
 # Requirements
 
@@ -40,11 +40,19 @@ These metrics have a labels of `keyspace` and `table` applied to them
 | `seastat_table_range_scan_latency_seconds` | Range Scan Latency for queries which this node is involved in | Summary |
 | `seastat_table_estimated_partitions` | Number of partitions in this table (estimated) | Gauge |
 | `seastat_table_pending_compactions` | Number of pending compactions on this table | Gauge |
+| `seastat_table_live_disk_space_used_bytes` | Disk space used for live cells in bytes | Gauge |
+| `seastat_table_total_disk_space_used_bytes` | Disk space used for all data in bytes | Gauge |
+| `seastat_table_live_sstables` | Number of live SSTables | Gauge |
+| `seastat_table_sstables_per_read` | Number of SSTables consulted per read query | Summary |
 | `seastat_table_max_partition_size_bytes` | Max Partition Size in bytes | Gauge |
 | `seastat_table_mean_partition_size_bytes` | Mean Partition Size in bytes | Gauge |
 | `seastat_table_bloom_filter_false_ratio` | False positive ratio of table’s bloom filter | Gauge |
+| `seastat_table_tombstones_scanned` | Number of tombstones scanned per read query | Summary |
+| `seastat_table_live_cells_scanned` | Number of live cells scanned per read query | Summary |
 | `seastat_table_key_cache_hit_percent` | Percent of key cache hits | Gauge
 | `seastat_table_repaired_percent` | Percent of table repaired | Gauge
+| `seastat_table_speculative_retries_total` | Total amount of speculative retries | Counter
+| `seastat_table_speculative_failed_retries_total` | Total amount of speculative failed retries | Counter
 
 ## CQL Metrics
 

--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -143,7 +143,7 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 		case "TotalDiskSpaceUsed":
 			stats.TotalDiskSpaceUsed = Gauge(val.Get("Count").GetInt64())
 		case "LiveSSTableCount":
-			stats.LiveSSTableCount = Gauge(val.Get("Value").GetInt64())
+			stats.LiveSSTables = Gauge(val.Get("Value").GetInt64())
 		case "SSTablesPerReadHistogram":
 			stats.SSTablesPerRead = parseHistogram(val.Get("Value"))
 		case "MaxPartitionSize":

--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -77,13 +77,22 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 		"ReadLatency",
 		"WriteLatency",
 		"RangeLatency",
+
 		"EstimatedPartitionCount",
 		"PendingCompactions",
+		"LiveDiskSpaceUsed",
+		"TotalDiskSpaceUsed",
+		"LiveSSTableCount",
+		"SSTablesPerReadHistogram",
 		"MaxPartitionSize",
 		"MeanPartitionSize",
 		"BloomFilterFalseRatio",
+		"TombstoneScannedHistogram",
+		"LiveCellsScannedHistogram",
 		"KeyCacheHitRate",
 		"PercentRepaired",
+		"SpeculativeRetries",
+		"SpeculativeFailedRetries",
 	}
 
 	mbeanGroups := make([][]string, 0, len(metricItems))
@@ -129,16 +138,32 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 			stats.EstimatedPartitionCount = Gauge(val.Get("Value").GetInt64())
 		case "PendingCompactions":
 			stats.PendingCompactions = Gauge(val.Get("Value").GetInt64())
+		case "LiveDiskSpaceUsed":
+			stats.LiveDiskSpaceUsed = Gauge(val.Get("Count").GetInt64())
+		case "TotalDiskSpaceUsed":
+			stats.TotalDiskSpaceUsed = Gauge(val.Get("Count").GetInt64())
+		case "LiveSSTableCount":
+			stats.LiveSSTableCount = Gauge(val.Get("Value").GetInt64())
+		case "SSTablesPerReadHistogram":
+			stats.SSTablesPerRead = parseHistogram(val.Get("Value"))
 		case "MaxPartitionSize":
 			stats.MaxPartitionSize = BytesGauge(val.Get("Value").GetInt64())
 		case "MeanPartitionSize":
 			stats.MeanPartitionSize = BytesGauge(val.Get("Value").GetInt64())
 		case "BloomFilterFalseRatio":
 			stats.BloomFilterFalseRatio = FloatGauge(val.Get("Value").GetInt64())
+		case "TombstoneScannedHistogram":
+			stats.TombstonesScanned = parseHistogram(val.Get("Value"))
+		case "LiveCellsScannedHistogram":
+			stats.LiveCellsScanned = parseHistogram(val.Get("Value"))
 		case "KeyCacheHitRate":
 			stats.KeyCacheHitRate = FloatGauge(val.Get("Value").GetInt64())
 		case "PercentRepaired":
 			stats.PercentRepaired = FloatGauge(val.Get("Value").GetInt64())
+		case "SpeculativeRetries":
+			stats.SpeculativeRetries = Counter(val.Get("Count").GetInt64())
+		case "SpeculativeFailedRetries":
+			stats.SpeculativeFailedRetries = Counter(val.Get("Count").GetInt64())
 		}
 	}
 	return stats, nil

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -12,7 +12,20 @@ type (
 	BytesGauge Gauge
 	// FloatGauge represents a point-in-time (float) value
 	FloatGauge float64
-	// Latency represents a latency distribution
+	// Histogram represents a Histogram distribution
+	Histogram struct {
+		Minimum       FloatGauge
+		Maximum       FloatGauge
+		Percentile75  FloatGauge
+		Percentile95  FloatGauge
+		Percentile99  FloatGauge
+		Percentile999 FloatGauge
+		Mean          FloatGauge
+		Count         Counter
+	}
+	// Latency represents a latency distribution. It's similar
+	// to a Histogram with the caveat that the fields are more
+	// based around durations than gauge values
 	Latency struct {
 		Minimum       time.Duration
 		Maximum       time.Duration
@@ -90,9 +103,15 @@ type TableStats struct {
 	// Table specific stats
 	EstimatedPartitionCount Gauge
 	PendingCompactions      Gauge
+	LiveDiskSpaceUsed       Gauge
+	TotalDiskSpaceUsed      Gauge
+	LiveSSTableCount        Gauge
+	SSTablesPerRead         Histogram
 	MaxPartitionSize        BytesGauge
 	MeanPartitionSize       BytesGauge
 	BloomFilterFalseRatio   FloatGauge
+	TombstonesScanned       Histogram
+	LiveCellsScanned        Histogram
 	KeyCacheHitRate         FloatGauge
 	PercentRepaired         FloatGauge
 }

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -101,19 +101,21 @@ type TableStats struct {
 	RangeLatency     Latency
 
 	// Table specific stats
-	EstimatedPartitionCount Gauge
-	PendingCompactions      Gauge
-	LiveDiskSpaceUsed       Gauge
-	TotalDiskSpaceUsed      Gauge
-	LiveSSTableCount        Gauge
-	SSTablesPerRead         Histogram
-	MaxPartitionSize        BytesGauge
-	MeanPartitionSize       BytesGauge
-	BloomFilterFalseRatio   FloatGauge
-	TombstonesScanned       Histogram
-	LiveCellsScanned        Histogram
-	KeyCacheHitRate         FloatGauge
-	PercentRepaired         FloatGauge
+	EstimatedPartitionCount  Gauge
+	PendingCompactions       Gauge
+	LiveDiskSpaceUsed        Gauge
+	TotalDiskSpaceUsed       Gauge
+	LiveSSTableCount         Gauge
+	SSTablesPerRead          Histogram
+	MaxPartitionSize         BytesGauge
+	MeanPartitionSize        BytesGauge
+	BloomFilterFalseRatio    FloatGauge
+	TombstonesScanned        Histogram
+	LiveCellsScanned         Histogram
+	KeyCacheHitRate          FloatGauge
+	PercentRepaired          FloatGauge
+	SpeculativeRetries       Counter
+	SpeculativeFailedRetries Counter
 }
 
 // CQLStats embeds stats about Prepared and Regular CQL statements

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -105,7 +105,7 @@ type TableStats struct {
 	PendingCompactions       Gauge
 	LiveDiskSpaceUsed        Gauge
 	TotalDiskSpaceUsed       Gauge
-	LiveSSTableCount         Gauge
+	LiveSSTables             Gauge
 	SSTablesPerRead          Histogram
 	MaxPartitionSize         BytesGauge
 	MeanPartitionSize        BytesGauge

--- a/jolokia/util.go
+++ b/jolokia/util.go
@@ -7,6 +7,34 @@ import (
 	"github.com/valyala/fastjson"
 )
 
+// parseHistogram takes a histogram map and converts the various fields
+// into a Histogram struct object
+//
+//    "StdDev": 0,
+//    "75thPercentile": 0,
+//    "Mean": null,
+//    "98thPercentile": 0,
+//    "Min": 0,
+//    "95thPercentile": 0,
+//    "99thPercentile": 0,
+//    "Max": 0,
+//    "999thPercentile": 0,
+//    "Count": 5,
+//    "50thPercentile": 0
+//
+func parseHistogram(val *fastjson.Value) Histogram {
+	return Histogram{
+		Minimum:       FloatGauge(val.Get("Min").GetFloat64()),
+		Maximum:       FloatGauge(val.Get("Max").GetFloat64()),
+		Percentile75:  FloatGauge(val.Get("75thPercentile").GetFloat64()),
+		Percentile95:  FloatGauge(val.Get("95thPercentile").GetFloat64()),
+		Percentile99:  FloatGauge(val.Get("99thPercentile").GetFloat64()),
+		Percentile999: FloatGauge(val.Get("999thPercentile").GetFloat64()),
+		Mean:          FloatGauge(val.Get("Mean").GetFloat64()),
+		Count:         Counter(val.Get("Count").GetInt64()),
+	}
+}
+
 // parseLatency takes a latency map and converts the various fields into
 // a Latency struct object so it's easier to work with
 //

--- a/server/collector.go
+++ b/server/collector.go
@@ -33,11 +33,18 @@ func (c *SeastatCollector) Describe(ch chan<- *prometheus.Desc) {
 		PromTableRangeScan,
 		PromTableEstimatedPartitionCount,
 		PromTablePendingCompactions,
+		PromTableLiveDiskSpaceUsed,
+		PromTableTotalDiskSpaceUsed,
+		PromTableLiveSSTables,
 		PromTableMaxPartitionSize,
 		PromTableMeanPartitionSize,
 		PromTableBloomFilterFalseRatio,
+		PromTableTombstonesScanned,
+		PromTableLiveCellsScanned,
 		PromTableKeyCacheHitRate,
 		PromTablePercentRepaired,
+		PromTableSpeculativeRetries,
+		PromTableSpeculativeFailedRetries,
 
 		// CQLStats
 		PromCQLPreparedStatementsCount,
@@ -163,6 +170,24 @@ func addTableStats(metrics ScrapedMetrics, ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(PromTablePendingCompactions,
 			prometheus.GaugeValue, float64(stat.PendingCompactions),
 			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableLiveDiskSpaceUsed,
+			prometheus.GaugeValue, float64(stat.LiveDiskSpaceUsed),
+			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableTotalDiskSpaceUsed,
+			prometheus.GaugeValue, float64(stat.TotalDiskSpaceUsed),
+			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableLiveSSTables,
+			prometheus.GaugeValue, float64(stat.LiveSSTables),
+			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstSummary(PromTableSSTablesPerRead,
+			uint64(stat.SSTablesPerRead.Count),
+			float64(stat.SSTablesPerRead.Count)*float64(stat.SSTablesPerRead.Mean),
+			map[float64]float64{
+				75.0: float64(stat.SSTablesPerRead.Percentile75),
+				95.0: float64(stat.SSTablesPerRead.Percentile95),
+				99.0: float64(stat.SSTablesPerRead.Percentile99),
+				99.9: float64(stat.SSTablesPerRead.Percentile999),
+			}, stat.Table.KeyspaceName, stat.Table.TableName)
 		ch <- prometheus.MustNewConstMetric(PromTableMaxPartitionSize,
 			prometheus.GaugeValue, float64(stat.MaxPartitionSize),
 			stat.Table.KeyspaceName, stat.Table.TableName)
@@ -172,11 +197,35 @@ func addTableStats(metrics ScrapedMetrics, ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(PromTableBloomFilterFalseRatio,
 			prometheus.GaugeValue, float64(stat.BloomFilterFalseRatio),
 			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstSummary(PromTableTombstonesScanned,
+			uint64(stat.TombstonesScanned.Count),
+			float64(stat.TombstonesScanned.Count)*float64(stat.TombstonesScanned.Mean),
+			map[float64]float64{
+				75.0: float64(stat.TombstonesScanned.Percentile75),
+				95.0: float64(stat.TombstonesScanned.Percentile95),
+				99.0: float64(stat.TombstonesScanned.Percentile99),
+				99.9: float64(stat.TombstonesScanned.Percentile999),
+			}, stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstSummary(PromTableLiveCellsScanned,
+			uint64(stat.LiveCellsScanned.Count),
+			float64(stat.LiveCellsScanned.Count)*float64(stat.LiveCellsScanned.Mean),
+			map[float64]float64{
+				75.0: float64(stat.LiveCellsScanned.Percentile75),
+				95.0: float64(stat.LiveCellsScanned.Percentile95),
+				99.0: float64(stat.LiveCellsScanned.Percentile99),
+				99.9: float64(stat.LiveCellsScanned.Percentile999),
+			}, stat.Table.KeyspaceName, stat.Table.TableName)
 		ch <- prometheus.MustNewConstMetric(PromTableKeyCacheHitRate,
 			prometheus.GaugeValue, float64(stat.KeyCacheHitRate),
 			stat.Table.KeyspaceName, stat.Table.TableName)
 		ch <- prometheus.MustNewConstMetric(PromTablePercentRepaired,
 			prometheus.GaugeValue, float64(stat.PercentRepaired),
+			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableSpeculativeRetries,
+			prometheus.GaugeValue, float64(stat.SpeculativeRetries),
+			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableSpeculativeFailedRetries,
+			prometheus.GaugeValue, float64(stat.SpeculativeFailedRetries),
 			stat.Table.KeyspaceName, stat.Table.TableName)
 	}
 }

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -67,6 +67,30 @@ var (
 		[]string{"keyspace", "table"}, nil,
 	)
 
+	PromTableLiveDiskSpaceUsed = prometheus.NewDesc(
+		"seastat_table_live_disk_space_used_bytes",
+		"Disk space used for live cells in bytes",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableTotalDiskSpaceUsed = prometheus.NewDesc(
+		"seastat_table_total_disk_space_used_bytes",
+		"Disk space used for all data in bytes",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableLiveSSTables = prometheus.NewDesc(
+		"seastat_table_live_sstables",
+		"Number of live SSTables",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableSSTablesPerRead = prometheus.NewDesc(
+		"seastat_table_sstables_per_read",
+		"Number of SSTables consulted per read query",
+		[]string{"keyspace", "table"}, nil,
+	)
+
 	PromTableMaxPartitionSize = prometheus.NewDesc(
 		"seastat_table_max_partition_size_bytes",
 		"Max Partition Size in bytes",
@@ -85,6 +109,18 @@ var (
 		[]string{"keyspace", "table"}, nil,
 	)
 
+	PromTableTombstonesScanned = prometheus.NewDesc(
+		"seastat_table_tombstones_scanned",
+		"Number of tombstones scanned per read query",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableLiveCellsScanned = prometheus.NewDesc(
+		"seastat_table_live_cells_scanned",
+		"Number of live cells scanned per read query",
+		[]string{"keyspace", "table"}, nil,
+	)
+
 	PromTableKeyCacheHitRate = prometheus.NewDesc(
 		"seastat_table_key_cache_hit_percent",
 		"Percent of key cache hits",
@@ -94,6 +130,18 @@ var (
 	PromTablePercentRepaired = prometheus.NewDesc(
 		"seastat_table_repaired_percent",
 		"Percent of table repaired",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableSpeculativeRetries = prometheus.NewDesc(
+		"seastat_table_speculative_retries_total",
+		"Total amount of speculative retries",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableSpeculativeFailedRetries = prometheus.NewDesc(
+		"seastat_table_speculative_failed_retries_total",
+		"Total amount of speculative failed retries",
 		[]string{"keyspace", "table"}, nil,
 	)
 )

--- a/server/scraper.go
+++ b/server/scraper.go
@@ -190,9 +190,9 @@ func (s *Scraper) scrapeAllMetrics() ScrapedMetrics {
 
 func (s *Scraper) scrapeTableMetrics() []jolokia.TableStats {
 	// The goal of this function is to scrape the table metrics in parallel.
-	// A few numbers were tried and 8 seemed to be the sweet spot with Jolokia.
+	// A few numbers were tried and 10 seemed to be a sweet spot with Jolokia.
 	// Ramping this too high may lead to stuck conns
-	const workers = 8
+	const workers = 10
 
 	type result struct {
 		table      jolokia.Table


### PR DESCRIPTION
This PR plumbs through some additional table level stats that are useful for Cassandra operators and are good for historic purposes to understand behaviour of a Cassandra cluster

The new table stat metrics are:

| Name          | Description   | Type |
| ------------- | ------------- | ---- |
| `seastat_table_live_disk_space_used_bytes` | Disk space used for live cells in bytes | Gauge |
| `seastat_table_total_disk_space_used_bytes` | Disk space used for all data in bytes | Gauge |
| `seastat_table_live_sstables` | Number of live SSTables | Gauge |
| `seastat_table_sstables_per_read` | Number of SSTables consulted per read query | Summary |
| `seastat_table_tombstones_scanned` | Number of tombstones scanned per read query | Summary |
| `seastat_table_live_cells_scanned` | Number of live cells scanned per read query | Summary |
| `seastat_table_speculative_retries_total` | Total amount of speculative retries | Counter
| `seastat_table_speculative_failed_retries_total` | Total amount of speculative failed retries | Counter