### PR TITLE
Add Cassandra Storage metrics 🎸

### DIFF
--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -74,11 +74,16 @@ type Client interface {
 	// MemoryStats returns memory information about the Java process
 	MemoryStats() (MemoryStats, error)
 
-	// GarbageCollectorStatus returns information about Garbage Collections
+	// GarbageCollectorStats returns information about Garbage Collections
 	// that occur in the process. Since there are different kinds of GC
 	// processes occurring, the stats are returned as a list with an item for
 	// each kind of GC step
 	GarbageCollectionStats() ([]GCStats, error)
+
+	// StorageStats gives information about the storage layer of Cassandra
+	// which encapsulates things like number of keyspaces and what nodes
+	// are part of the cluster
+	StorageStats() (StorageStats, error)
 }
 
 // Table embeds information about a Keyspace and Table that exists in
@@ -168,4 +173,16 @@ type GCStats struct {
 	Count       Counter // How many collections have occurred
 	LastGC      time.Duration
 	Accumulated time.Duration
+}
+
+// StorageStats embeds information gathered from storage information
+// in Cassandra such as the number of nodes and the state they are in
+type StorageStats struct {
+	KeyspaceCount    Counter
+	TokenCount       Counter
+	LiveNodes        []string
+	UnreachableNodes []string
+	JoiningNodes     []string
+	MovingNodes      []string
+	LeavingNodes     []string
 }

--- a/jolokia/util.go
+++ b/jolokia/util.go
@@ -118,3 +118,17 @@ func extractAttributes(tag string) map[string]string {
 	}
 	return out
 }
+
+// valueToStringArray takes in an array of fastjson value types
+// and converts the ones which are a string value to output an
+// array of strings
+func valueToStringArray(in []*fastjson.Value) []string {
+	out := make([]string, 0, len(in))
+	for _, val := range in {
+		str := string(val.GetStringBytes())
+		if str != "" {
+			out = append(out, str)
+		}
+	}
+	return out
+}

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -310,3 +310,24 @@ var (
 		[]string{"name"}, nil,
 	)
 )
+
+// StorageStats
+var (
+	PromStorageKeyspaces = prometheus.NewDesc(
+		"seastat_storage_keyspaces",
+		"Number of keyspaces",
+		[]string{}, nil,
+	)
+
+	PromStorageTokens = prometheus.NewDesc(
+		"seastat_storage_tokens",
+		"Number of tokens",
+		[]string{}, nil,
+	)
+
+	PromStorageNodeStatus = prometheus.NewDesc(
+		"seastat_storage_node_status",
+		"Status of the other nodes from Cassandra's point of view",
+		[]string{"node", "status"}, nil,
+	)
+)

--- a/server/scraper.go
+++ b/server/scraper.go
@@ -40,6 +40,7 @@ type ScrapedMetrics struct {
 	ConnectedClients   *jolokia.Gauge
 	MemoryStats        *jolokia.MemoryStats
 	GCStats            []jolokia.GCStats
+	StorageStats       *jolokia.StorageStats
 
 	ScrapeDuration time.Duration
 	ScrapeTime     time.Time
@@ -181,6 +182,13 @@ func (s *Scraper) scrapeAllMetrics() ScrapedMetrics {
 		logrus.Debugf("🦂 Could not get GC stats: %v", err)
 	} else {
 		out.GCStats = gcStats
+	}
+
+	storageStats, err := s.client.StorageStats()
+	if err != nil {
+		logrus.Debugf("🦂 Could not get Storage stats: %v", err)
+	} else {
+		out.StorageStats = &storageStats
 	}
 
 	out.ScrapeDuration = time.Since(scrapeStart)


### PR DESCRIPTION
This allows us to identify the state of each node in our cluster as well as getting metrics about the number of overall keyspaces and tokens per node