### PR TITLE
Fix Live Cells Scanned metric using wrong metric name on Cassandra

### DIFF
--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -88,7 +88,7 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 		"MeanPartitionSize",
 		"BloomFilterFalseRatio",
 		"TombstoneScannedHistogram",
-		"LiveCellsScannedHistogram",
+		"LiveScannedHistogram",
 		"KeyCacheHitRate",
 		"PercentRepaired",
 		"SpeculativeRetries",
@@ -154,7 +154,7 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 			stats.BloomFilterFalseRatio = FloatGauge(val.Get("Value").GetFloat64())
 		case "TombstoneScannedHistogram":
 			stats.TombstonesScanned = parseHistogram(val)
-		case "LiveCellsScannedHistogram":
+		case "LiveScannedHistogram":
 			stats.LiveCellsScanned = parseHistogram(val)
 		case "KeyCacheHitRate":
 			stats.KeyCacheHitRate = FloatGauge(val.Get("Value").GetFloat64())


### PR DESCRIPTION
The metric name is `LiveScannedHistogram` to get the number of scanned cells per read

http://cassandra.apache.org/doc/latest/operating/metrics.html