### PR TITLE
Add Compare and Set Latency metrics 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ These metrics have a labels of `keyspace` and `table` applied to them
 | `seastat_table_read_latency_seconds` | Read Latency for queries which this node is involved in | Summary |
 | `seastat_table_write_latency_seconds` | Write Latency for queries which this node is involved in | Summary |
 | `seastat_table_range_scan_latency_seconds` | Range Scan Latency for queries which this node is involved in | Summary |
+| `seastat_table_cas_propose_latency_seconds` | Compare and Set Propose Latency for queries | Summary |
+| `seastat_table_cas_commit_latency_seconds` | Compare and Set Commit Latency for queries | Summary |
 | `seastat_table_estimated_partitions` | Number of partitions in this table (estimated) | Gauge |
 | `seastat_table_pending_compactions` | Number of pending compactions on this table | Gauge |
 | `seastat_table_live_disk_space_used_bytes` | Disk space used for live cells in bytes | Gauge |

--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -77,6 +77,8 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 		"ReadLatency",
 		"WriteLatency",
 		"RangeLatency",
+		"CasPropose",
+		"CasCommit",
 
 		"EstimatedPartitionCount",
 		"PendingCompactions",
@@ -132,6 +134,10 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 			stats.WriteLatency = parseLatency(val)
 		case "RangeLatency":
 			stats.RangeLatency = parseLatency(val)
+		case "CasPropose":
+			stats.CASProposeLatency = parseLatency(val)
+		case "CasCommit":
+			stats.CASCommitLatency = parseLatency(val)
 
 		// Table specific stats
 		case "EstimatedPartitionCount":

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -98,12 +98,14 @@ type TableStats struct {
 	Table Table
 
 	// Latency stats
-	CoordinatorRead  Latency
-	CoordinatorWrite Latency
-	CoordinatorScan  Latency
-	ReadLatency      Latency
-	WriteLatency     Latency
-	RangeLatency     Latency
+	CoordinatorRead   Latency
+	CoordinatorWrite  Latency
+	CoordinatorScan   Latency
+	ReadLatency       Latency
+	WriteLatency      Latency
+	RangeLatency      Latency
+	CASProposeLatency Latency
+	CASCommitLatency  Latency
 
 	// Table specific stats
 	EstimatedPartitionCount  Gauge

--- a/server/collector.go
+++ b/server/collector.go
@@ -31,6 +31,8 @@ func (c *SeastatCollector) Describe(ch chan<- *prometheus.Desc) {
 		PromTableRead,
 		PromTableWrite,
 		PromTableRangeScan,
+		PromTableCASPropose,
+		PromTableCASCommit,
 		PromTableEstimatedPartitionCount,
 		PromTablePendingCompactions,
 		PromTableLiveDiskSpaceUsed,
@@ -168,6 +170,24 @@ func addTableStats(metrics ScrapedMetrics, ch chan<- prometheus.Metric) {
 				95.0: stat.RangeLatency.Percentile95.Seconds(),
 				99.0: stat.RangeLatency.Percentile99.Seconds(),
 				99.9: stat.RangeLatency.Percentile999.Seconds(),
+			}, stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstSummary(PromTableCASPropose,
+			uint64(stat.CASProposeLatency.Count),
+			float64(stat.CASProposeLatency.Count)*stat.CASProposeLatency.Mean.Seconds(),
+			map[float64]float64{
+				75.0: stat.CASProposeLatency.Percentile75.Seconds(),
+				95.0: stat.CASProposeLatency.Percentile95.Seconds(),
+				99.0: stat.CASProposeLatency.Percentile99.Seconds(),
+				99.9: stat.CASProposeLatency.Percentile999.Seconds(),
+			}, stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstSummary(PromTableCASCommit,
+			uint64(stat.CASCommitLatency.Count),
+			float64(stat.CASCommitLatency.Count)*stat.CASCommitLatency.Mean.Seconds(),
+			map[float64]float64{
+				75.0: stat.CASCommitLatency.Percentile75.Seconds(),
+				95.0: stat.CASCommitLatency.Percentile95.Seconds(),
+				99.0: stat.CASCommitLatency.Percentile99.Seconds(),
+				99.9: stat.CASCommitLatency.Percentile999.Seconds(),
 			}, stat.Table.KeyspaceName, stat.Table.TableName)
 
 		ch <- prometheus.MustNewConstMetric(PromTableEstimatedPartitionCount,

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -55,6 +55,18 @@ var (
 		[]string{"keyspace", "table"}, nil,
 	)
 
+	PromTableCASPropose = prometheus.NewDesc(
+		"seastat_table_cas_propose_latency_seconds",
+		"Paxos propose latency",
+		[]string{"keyspace", "table"}, nil,
+	)
+
+	PromTableCASCommit = prometheus.NewDesc(
+		"seastat_table_cas_commit_latency_seconds",
+		"Paxos commit latency",
+		[]string{"keyspace", "table"}, nil,
+	)
+
 	PromTableEstimatedPartitionCount = prometheus.NewDesc(
 		"seastat_table_estimated_partitions",
 		"Number of partitions in this table (estimated)",


### PR DESCRIPTION
This allows us to identify compare and set operations on a granular per keyspace/table level