### PR TITLE
Add metric for Internal Exceptions and refactor Node Status metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,17 +137,11 @@ These metrics come from Cassandra's storage service which keeps track of the clu
 | Name          | Description   | Type |
 | ------------- | ------------- | ---- |
 | `seastat_storage_keyspaces` | Number of keyspaces reported by Cassandra | Gauge |
-| `seastat_storage_tokens` | Number of tokens reported by Cassandra  | Gauge |
-| `seastat_storage_node_status` | Status (`live`, `unreachable`, `joining`, `moving`, `leaving`) of each node in the cluster (tagged by node and status) | Gauge |
-
-## Hint Metrics
-
-These metrics come from the [Storage](https://cassandra.apache.org/doc/latest/operating/metrics.html#storage-metrics) metric which keeps track of hints, node load and storage exceptions.
-
-| Name          | Description   | Type |
-| ------------- | ------------- | ---- |
-| `seastat_hints_total` | Number of hint messages written to this node since [re]start. Includes one entry for each host to be hinted per hint. | Counter |
-| `seastat_hints_in_progress` | Number of hints attempting to be sent currently from this node. | Gauge |
+| `seastat_storage_tokens` | Number of tokens reported by Cassandra | Gauge |
+| `seastat_storage_node_status` | State (`up` or `down`) and Status (`live`, `unreachable`, `joining`, `moving`, `leaving`) of each node in the cluster (tagged by node, state and status) | Gauge |
+| `seastat_internal_exceptions` | Number of internal uncaught exceptions | Counter |
+| `seastat_hints_total` | Number of hint messages written to this node since [re]start. Includes one entry for each host to be hinted per hint | Counter |
+| `seastat_hints_in_progress` | Number of hints attempting to be sent currently from this node | Gauge |
 
 ## Scrape Metrics
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ These metrics come from Cassandra's storage service which keeps track of the clu
 | `seastat_storage_keyspaces` | Number of keyspaces reported by Cassandra | Gauge |
 | `seastat_storage_tokens` | Number of tokens reported by Cassandra | Gauge |
 | `seastat_storage_node_status` | State (`up` or `down`) and Status (`live`, `unreachable`, `joining`, `moving`, `leaving`) of each node in the cluster (tagged by node, state and status). Note that a node may be marked as 'unreachable' even if it's been removed from the cluster but is a seed node | Gauge |
+| `seastat_storage_node_host_id` | IP and Node UUID of each node that is part of the ring | Gauge|
 | `seastat_internal_exceptions` | Number of internal uncaught exceptions | Counter |
 | `seastat_hints_total` | Number of hint messages written to this node since [re]start. Includes one entry for each host to be hinted per hint | Counter |
 | `seastat_hints_in_progress` | Number of hints attempting to be sent currently from this node | Gauge |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ These metrics come from Cassandra's storage service which keeps track of the clu
 | ------------- | ------------- | ---- |
 | `seastat_storage_keyspaces` | Number of keyspaces reported by Cassandra | Gauge |
 | `seastat_storage_tokens` | Number of tokens reported by Cassandra | Gauge |
-| `seastat_storage_node_status` | State (`up` or `down`) and Status (`live`, `unreachable`, `joining`, `moving`, `leaving`) of each node in the cluster (tagged by node, state and status) | Gauge |
+| `seastat_storage_node_status` | State (`up` or `down`) and Status (`live`, `unreachable`, `joining`, `moving`, `leaving`) of each node in the cluster (tagged by node, state and status). Note that a node may be marked as 'unreachable' even if it's been removed from the cluster but is a seed node | Gauge |
 | `seastat_internal_exceptions` | Number of internal uncaught exceptions | Counter |
 | `seastat_hints_total` | Number of hint messages written to this node since [re]start. Includes one entry for each host to be hinted per hint | Counter |
 | `seastat_hints_in_progress` | Number of hints attempting to be sent currently from this node | Gauge |

--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -419,6 +419,7 @@ func (c *jolokiaClient) StorageStats() (StorageStats, error) {
 		"JoiningNodes",
 		"MovingNodes",
 		"LeavingNodes",
+		"EndpointToHostId",
 	}
 
 	v, err := c.bulkRequest("org.apache.cassandra.db", [][]string{{"type=StorageService"}}, [][]string{attributes})
@@ -438,6 +439,7 @@ func (c *jolokiaClient) StorageStats() (StorageStats, error) {
 		stats.JoiningNodes = valueToStringArray(item.Get("value", "JoiningNodes").GetArray())
 		stats.MovingNodes = valueToStringArray(item.Get("value", "MovingNodes").GetArray())
 		stats.LeavingNodes = valueToStringArray(item.Get("value", "LeavingNodes").GetArray())
+		stats.NodeEndpoints = valueObjectToStringMap(item.Get("value", "EndpointToHostId").GetObject())
 	}
 	return stats, nil
 }

--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -442,15 +442,14 @@ func (c *jolokiaClient) StorageStats() (StorageStats, error) {
 	return stats, nil
 }
 
-// HintStats gives information on hints being created and handed off in Cassandra
-// Hint metrics are ephemeral and reset when the Cassandra process restarts
-func (c *jolokiaClient) HintStats() (HintStats, error) {
+// StorageCoreStats gives information on hints and internal exceptions
+func (c *jolokiaClient) StorageCoreStats() (StorageCoreStats, error) {
 	v, err := c.read("org.apache.cassandra.metrics", "type=Storage", "name=*")
 	if err != nil {
-		return HintStats{}, fmt.Errorf("err reading CQL stats: %v", err)
+		return StorageCoreStats{}, fmt.Errorf("err reading storage stats: %v", err)
 	}
 
-	stats := HintStats{}
+	stats := StorageCoreStats{}
 	v.Get("value").GetObject().Visit(func(key []byte, val *fastjson.Value) {
 		attributes := extractAttributes(string(key))
 		switch attributes["name"] {
@@ -458,6 +457,8 @@ func (c *jolokiaClient) HintStats() (HintStats, error) {
 			stats.TotalHintsInProgress = Gauge(val.Get("Count").GetInt64())
 		case "TotalHints":
 			stats.TotalHints = Counter(val.Get("Count").GetInt64())
+		case "Exceptions":
+			stats.InternalExceptions = Counter(val.Get("Count").GetInt64())
 		}
 	})
 	return stats, nil

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -191,6 +191,7 @@ type StorageStats struct {
 	JoiningNodes     []string
 	MovingNodes      []string
 	LeavingNodes     []string
+	NodeEndpoints	 map[string]string
 }
 
 // StorageCoreStats embeds information gathered from the Storage metric in

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -85,9 +85,9 @@ type Client interface {
 	// are part of the cluster
 	StorageStats() (StorageStats, error)
 
-	// HintStats gives information on hints being created and handed off in Cassandra
-	// Hint metrics are ephemeral and reset when the Cassandra process restarts
-	HintStats() (HintStats, error)
+	// StorageCoreStats gives information on the storage core such as
+	// hints and exceptions
+	StorageCoreStats() (StorageCoreStats, error)
 }
 
 // Table embeds information about a Keyspace and Table that exists in
@@ -193,9 +193,12 @@ type StorageStats struct {
 	LeavingNodes     []string
 }
 
-// HintStats embeds information gathered from the Storage metric in
-// cassandra such as the number of total hints and hints being handed off
-type HintStats struct {
+// StorageCoreStats embeds information gathered from the Storage metric in
+// Cassandra such as the number of total hints and hints being handed off
+// and internal exceptions
+type StorageCoreStats struct {
+	InternalExceptions 	 Counter
+	LoadBytes 			 Gauge
 	TotalHintsInProgress Gauge
 	TotalHints           Counter
 }

--- a/jolokia/util.go
+++ b/jolokia/util.go
@@ -132,3 +132,16 @@ func valueToStringArray(in []*fastjson.Value) []string {
 	}
 	return out
 }
+
+// valueObjectToStringMap takes in a fastjson objects and extracts
+// the keys and values as a map of string to string
+func valueObjectToStringMap(in *fastjson.Object) map[string]string {
+	out := make(map[string]string, 8)
+	in.Visit(func(key []byte, val *fastjson.Value) {
+		str := string(val.GetStringBytes())
+		if len(key) > 0 && str != "" {
+			out[string(key)] = string(val.GetStringBytes())
+		}
+	})
+	return out
+}

--- a/server/collector.go
+++ b/server/collector.go
@@ -86,6 +86,7 @@ func (c *SeastatCollector) Describe(ch chan<- *prometheus.Desc) {
 		PromStorageKeyspaces,
 		PromStorageTokens,
 		PromStorageNodeStatus,
+		PromStorageNodeEndpointID,
 
 		// StorageCoreStats
 		PromTotalHintsInProgress,
@@ -428,6 +429,11 @@ func addStorageStats(metrics ScrapedMetrics, ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(PromStorageNodeStatus,
 			prometheus.GaugeValue, 1.0,
 			node, status, state)
+	}
+
+	for ip, id := range metrics.StorageStats.NodeEndpoints {
+		ch <- prometheus.MustNewConstMetric(PromStorageNodeEndpointID,
+			prometheus.GaugeValue, 1.0, ip, id)
 	}
 }
 

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -340,11 +340,17 @@ var (
 	PromStorageNodeStatus = prometheus.NewDesc(
 		"seastat_storage_node_status",
 		"Status of the other nodes from Cassandra's point of view",
-		[]string{"node", "status"}, nil,
+		[]string{"node", "status", "state"}, nil,
 	)
 )
 
 var (
+	PromStorageInternalExceptions = prometheus.NewDesc(
+		"seastat_internal_exceptions",
+		"Number of internal exceptions caught",
+		[]string{}, nil,
+	)
+
 	PromTotalHintsInProgress = prometheus.NewDesc(
 		"seastat_hints_in_progress",
 		"Number of hints attempting to be handed off since Cassandra started",

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -342,6 +342,12 @@ var (
 		"Status of the other nodes from Cassandra's point of view",
 		[]string{"node", "status", "state"}, nil,
 	)
+
+	PromStorageNodeEndpointID = prometheus.NewDesc(
+		"seastat_storage_node_host_id",
+		"Host IDs of the nodes in the cluster",
+		[]string{"node", "id"}, nil,
+	)
 )
 
 var (

--- a/server/scraper.go
+++ b/server/scraper.go
@@ -41,7 +41,7 @@ type ScrapedMetrics struct {
 	MemoryStats        *jolokia.MemoryStats
 	GCStats            []jolokia.GCStats
 	StorageStats       *jolokia.StorageStats
-	HintStats          *jolokia.HintStats
+	StorageCoreStats   *jolokia.StorageCoreStats
 
 	ScrapeDuration time.Duration
 	ScrapeTime     time.Time
@@ -192,11 +192,11 @@ func (s *Scraper) scrapeAllMetrics() ScrapedMetrics {
 		out.StorageStats = &storageStats
 	}
 
-	hintStats, err := s.client.HintStats()
+	storageCoreStats, err := s.client.StorageCoreStats()
 	if err != nil {
-		logrus.Debugf("🦂 Could not get Hint stats: %v", err)
+		logrus.Debugf("🦂 Could not get Storage Core stats: %v", err)
 	} else {
-		out.HintStats = &hintStats
+		out.StorageCoreStats = &storageCoreStats
 	}
 
 	out.ScrapeDuration = time.Since(scrapeStart)


### PR DESCRIPTION
Node Status metrics now have a separate tag for up and down, and then live/joining/leaving/unreachable status

This means we go from this
```
seastat_storage_node_status{node="172.17.0.2",status="live"} 1
```

To this
```
seastat_storage_node_status{node="172.17.0.2",state="up",status="live"} 1
```

Do note that previously if a node was joining/leaving, we would emit two metrics
```
seastat_storage_node_status{node="172.17.0.2",status="live"} 1
seastat_storage_node_status{node="172.17.0.2",status="joining"} 1
```

This was confusing and now we emit a single metric of the actual state
```
seastat_storage_node_status{node="172.17.0.2",state="up",status="live"} 1
```
