### PR TITLE
Export the compression ratio per table

### DIFF
--- a/jolokia/client.go
+++ b/jolokia/client.go
@@ -95,6 +95,7 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 		"PercentRepaired",
 		"SpeculativeRetries",
 		"SpeculativeFailedRetries",
+		"CompressionRatio",
 	}
 
 	mbeanGroups := make([][]string, 0, len(metricItems))
@@ -170,6 +171,8 @@ func (c *jolokiaClient) TableStats(table Table) (TableStats, error) {
 			stats.SpeculativeRetries = Counter(val.Get("Count").GetInt64())
 		case "SpeculativeFailedRetries":
 			stats.SpeculativeFailedRetries = Counter(val.Get("Count").GetInt64())
+		case "CompressionRatio":
+			stats.CompressionRatio = FloatGauge(val.Get("Value").GetFloat64())
 		}
 	}
 	return stats, nil

--- a/jolokia/jolokia.go
+++ b/jolokia/jolokia.go
@@ -127,6 +127,7 @@ type TableStats struct {
 	PercentRepaired          FloatGauge
 	SpeculativeRetries       Counter
 	SpeculativeFailedRetries Counter
+	CompressionRatio         FloatGauge
 }
 
 // CQLStats embeds stats about Prepared and Regular CQL statements

--- a/server/collector.go
+++ b/server/collector.go
@@ -261,6 +261,9 @@ func addTableStats(metrics ScrapedMetrics, ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(PromTableSpeculativeFailedRetries,
 			prometheus.GaugeValue, float64(stat.SpeculativeFailedRetries),
 			stat.Table.KeyspaceName, stat.Table.TableName)
+		ch <- prometheus.MustNewConstMetric(PromTableCompressionRatio,
+			prometheus.GaugeValue, float64(stat.CompressionRatio),
+			stat.Table.KeyspaceName, stat.Table.TableName)
 	}
 }
 

--- a/server/prom_metrics.go
+++ b/server/prom_metrics.go
@@ -156,6 +156,12 @@ var (
 		"Total amount of speculative failed retries",
 		[]string{"keyspace", "table"}, nil,
 	)
+
+	PromTableCompressionRatio = prometheus.NewDesc(
+		"seastat_table_compression_ratio",
+		"Compression ratio for the table (a ratio of compressed size over uncompressed size)",
+		[]string{"keyspace", "table"}, nil,
+	)
 )
 
 // CQLStats


### PR DESCRIPTION
This PR adds a new metric (`seastat_table_compression_ratio`) to get the compression ratio of a table