### PR TITLE
Support Go 1.14 and Go 1.15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
   - 1.14.x
+  - 1.15.x
 
 script: go test -v ./...


### PR DESCRIPTION
Go 1.15 has been around for a while. Seastat typically supports the last two Go versions officially so this PR updates the TravisCI to test against Go 1.15 (and removing Go 1.13)